### PR TITLE
Add a link to detailed instructions for QtCreator

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -49,7 +49,7 @@ To build **CsoundQt**, you must have installed [**Csound**](csound.github.io) fi
 
 To build **CsoundQt** you need [**Qt**](http://qt-project.org/) (version 4.8 or 5.0+). The [**libsndfile**](http://www.mega-nerd.com/libsndfile/) library will allow recording the realtime output of Csound to a file. From version 0.7 onwards, CsoundQt can be built with [PythonQt](http://pythonqt.sourceforge.net/) support. Global MIDI I/O and control of the CsoundQt widgets can also be enabled through the [RtMidi](http://www.music.mcgill.ca/~gary/rtmidi/) library.
 
-The easiest way to build CsoundQt is to open its qcs.pro file in **QtCreator** and build it there. You can download and install Qt development kit (including QtCreator and all necessary libraries) from [QT page](http://www.qt.io/download-open-source/). It is recommended to use **Qt 5.3 or newer**, to be able to use CsoundQt's **Virtual Midi Keyboard**.
+The easiest way to build CsoundQt is to open its qcs.pro file in **QtCreator** and build it there (A step-by-step instruction [**here**](https://github.com/CsoundQt/CsoundQt/wiki)). You can download and install Qt development kit (including QtCreator and all necessary libraries) from [QT page](http://www.qt.io/download-open-source/). It is recommended to use **Qt 5.3 or newer**, to be able to use CsoundQt's **Virtual Midi Keyboard**.
 
 CsoundQt uses qmake to build, so you can build on the **command line** with:
 


### PR DESCRIPTION
It is not clear at this paragraph how to build CsoundQt with QtCreator - when I first read it, I didn't find a way to build it with QtCreator, so I went ahead building it with the command line, which failed after a few hours of trying different configurations. So a link at this paragraph to the wiki page would be helpful for newbies like me :)