### PR TITLE
Install target fixes for packagers

### DIFF
--- a/mime-types/add_csound_mimetypes.sh
+++ b/mime-types/add_csound_mimetypes.sh
@@ -1,7 +1,10 @@
 #!/bin/sh 
 
 #copy icon for csound mimetypes
-INSTALLDIR=/usr #~/.local # use the latter one for local install
+INSTALLDIR="$1"
+if [ -z "$INSTALLDIR" ] ; then
+	INSTALLDIR=/usr #~/.local # use the latter one for local install
+fi
 ICONDIR=$INSTALLDIR/share/icons/hicolor/128x128/mimetypes 
 mkdir -v -p $ICONDIR
 cp -v csound-light-128.png $ICONDIR/csound.png
@@ -11,6 +14,11 @@ MIMEDIR=$INSTALLDIR/share/mime # or /usr/share/mime
 DESTDIR=$MIMEDIR/packages 
 mkdir -v -p $DESTDIR # make if does not exist
 cp -v *.xml $DESTDIR
-update-mime-database -V $MIMEDIR
+# Only update db if it already exists
+# packages will install into empty trees and
+# do not need to update
+if [ -f "$MIMEDIR/mime.cache" ] ; then
+	update-mime-database -V $MIMEDIR
+fi
 
 echo "You may need to log out and log in to make changes effective." 

--- a/qcs.pro
+++ b/qcs.pro
@@ -155,10 +155,14 @@ message(TARGET is:      $${TARGET})
 # install commands for linux (for make install)
 # use 'sudo make install' for system wide installation
 unix {
-	INSTALL_DIR=/usr/local  # ~  #for HOME
-	SHARE_DIR=/usr/share # ~/.local for HOME install
+	isEmpty(INSTALL_DIR) {
+		INSTALL_DIR=/usr/local  # ~  #for HOME
+	}
+	isEmpty(SHARE_DIR) {
+		SHARE_DIR=/usr/share # ~/.local for HOME install
+	}
 	target.path = $$INSTALL_DIR/bin
-	target.commands = ln -sf $$INSTALL_DIR/bin/$$TARGET $$INSTALL_DIR/bin/csoundqt #	 create link always with the same name
+	target.commands = ln -sf $$TARGET $(INSTALL_ROOT)/$$INSTALL_DIR/bin/csoundqt #	 create link always with the same name
 	target.files = $$DESTDIR/$$TARGET
 
 
@@ -168,8 +172,8 @@ unix {
 	icon.path=$$SHARE_DIR/icons # not sure in fact, if /usr/share/icons is enough or better to put into hicolor...
 	icon.files=images/qtcs.svg
 
-	mimetypes.path=$$PWD # in some reason path must be set to create install target in Makefile
-	mimetypes.commands = cd $$PWD/mime-types/; ./add_csound_mimetypes.sh
+	mimetypes.path=$$INSTALL_DIR # in some reason path must be set to create install target in Makefile
+	mimetypes.commands = cd $$PWD/mime-types/; ./add_csound_mimetypes.sh $(INSTALL_ROOT)/$$INSTALL_DIR
 
 
 	#TODO: mime types


### PR DESCRIPTION
Allow overriding the install paths.
Avoid the mime update step when there is no cache
Allow installing into an INSTALL_ROOT

Updated from #201 . Now use the mime cache as flag file to determine if the db needs updating.