### PR TITLE
Fix install link of fixed csoundqt name

### DIFF
--- a/qcs.pro
+++ b/qcs.pro
@@ -173,7 +173,7 @@ unix:!macx {
 		SHARE_DIR=/usr/share # ~/.local for HOME install
 	}
 	target.path = $$INSTALL_DIR/bin
-	target.commands = ln -sf  $(INSTALL_ROOT)/$$INSTALL_DIR/bin/$$TARGET $(INSTALL_ROOT)/$$INSTALL_DIR/bin/csoundqt #	 create link always with the same name
+	target.commands = ln -sf $$TARGET $(INSTALL_ROOT)/$$INSTALL_DIR/bin/csoundqt #	 create link always with the same name
 	target.files = $$OUT_PWD/$$DESTDIR/$$TARGET
 
 


### PR DESCRIPTION
The link should be relative, but was being generated targeting the install directory, which might be inside the build tree if using DESTDIR:

```
E: csoundqt: dir-or-file-in-tmp symlink usr/bin/csoundqt point to /tmp/build-area/csoundqt-0.9.4/debian/tmp/usr/bin/CsoundQt-d-cs6
```