### PR TITLE
add possible path for the example files for nix compatability

### DIFF
--- a/src/qutecsound.cpp
+++ b/src/qutecsound.cpp
@@ -3978,7 +3978,8 @@ QString CsoundQt::getExamplePath(QString dir)
                   << "/usr/share/csoundqt/Examples/" << qApp->applicationDirPath() + "/../src/Examples/"
                   << qApp->applicationDirPath() + "/../../csoundqt/src/Examples/"
                   <<  "/../../qutecsound/src/Examples/"
-                  << "~/.local/share/qutecsound/Examples/" << "/usr/share/qutecsound/Examples/";
+                  << "~/.local/share/qutecsound/Examples/" << "/usr/share/qutecsound/Examples/"
+                  << qApp->applicationDirPath() + "/../share/csoundqt/Examples/";
 
     foreach (QString path, possiblePaths) {
         path += dir;


### PR DESCRIPTION
By adding this, the example files (floss examples, iain mccurdy etc) will appear in the dropdown menu on Nix(Os) distros. The nix build system is encapsulated with shared and bin belonging to same root directory. For now I patch this in nix https://github.com/NixOS/nixpkgs/pull/56050