### PR TITLE
Fix the "table of contents"

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,13 +1,13 @@
 Build instructions for CsoundQt
 ===============================
 
--       [Getting the Sources](#sources)     
--       [Building](#building)        
--       [RtMidi support](#rtmidi)        
--       [Building with PythonQt support](#pythonqt)     
--       [Notes for OSX](#osx)
--       [Notes for Linux](#linux)
--       [Notes for Windows](#windows)
+- [Getting the Sources](#sources)     
+- [Building](#building)        
+- [RtMidi support](#rtmidi)        
+- [Building with PythonQt support](#pythonqt)     
+- [Notes for OSX](#osx)
+- [Notes for Linux](#linux)
+- [Notes for Windows](#windows)
 
 
 


### PR DESCRIPTION
For some reason the ToC on `BUILDING.md` looks like this:

![image](https://user-images.githubusercontent.com/66189242/120403550-eead1100-c333-11eb-83bc-54089d4c4a15.png)

this PR fixes it and now will look like this:

![image](https://user-images.githubusercontent.com/66189242/120403616-100dfd00-c334-11eb-8adb-550f8e54c239.png)

